### PR TITLE
Empty the requirements file

### DIFF
--- a/requirements.lock
+++ b/requirements.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: proxy-node
-  repository: file://../verify-proxy-node/proxy-node-chart
-  version: 0.2.0
-digest: sha256:5b976562743161d4fd51e3a231af4112b43c75234ad4e6ef50825fd58b1ed690
-generated: 2019-01-25T20:19:24.746962Z

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,4 +1,0 @@
-dependencies:
-- name: proxy-node
-  version: "0.2.0"
-  repository: "file://../verify-proxy-node/proxy-node-chart"


### PR DESCRIPTION
This is a TMP fix, as we're referencing a local filepath which will by
all means break in real live flux environment.

Removing it should prevent the dependency from being upgraded.