### PR TITLE
Add metadata ingress

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -11,6 +11,10 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "metadata.host" -}}
+{{- printf "%s-%s.%s" .Release.Name "metadata" (required "global.cluster.domain is required" .Values.global.cluster.domain) | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "connector.entityID" -}}
 {{- if .Values.stubConnector.enabled -}}
 https://{{ include "connector.host" . }}

--- a/templates/metadata-ingress.yaml
+++ b/templates/metadata-ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-metadata
+  labels:
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    app.kubernetes.io/name: {{ .Release.Name }}-metadata
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  tls:
+    - hosts:
+      - {{ include "metadata.host" . }}
+      secretName: {{ .Release.Name }}-metadata-ingress
+  rules:
+    - host: {{ include "metadata.host" . }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ .Release.Name }}-proxy-metadata
+              servicePort: 80


### PR DESCRIPTION
## What

We need to be exposing the metadata endpoint for any country that will
be attempting to connect.

The metadata is generated via the VMC and nothing is pointing to the
created service.

I'm a little uneasy about the `serviceName`, as it's pure guess at this
point.

## How to review

- Code review
- **Optionally:** Template it out yourself and apply
  - Delete ingress after
