### PR TITLE
Separate pods that talk to HSMs from ESP

### DIFF
--- a/templates/esp-deployment.yaml
+++ b/templates/esp-deployment.yaml
@@ -21,6 +21,14 @@ spec:
         app.kubernetes.io/name: esp
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: talksToHsm
+                operator: Exists
+            topologyKey: "kubernetes.io/hostname"
       restartPolicy: Always
       containers:
       - name: esp

--- a/templates/stub-connector-deployment.yaml
+++ b/templates/stub-connector-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       labels:
         app.kubernetes.io/name: connector
         app.kubernetes.io/instance: {{ .Release.Name }}
+        talksToHsm: ""
     spec:
       restartPolicy: Always
       volumes:

--- a/templates/translator-deployment.yaml
+++ b/templates/translator-deployment.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: translator
         app.kubernetes.io/instance: {{ .Release.Name }}
+        talksToHsm: ""
     spec:
       restartPolicy: Always
       volumes:

--- a/templates/vmc-statefulset.yaml
+++ b/templates/vmc-statefulset.yaml
@@ -20,6 +20,7 @@ spec:
       labels:
         app.kubernetes.io/name: vmc
         app.kubernetes.io/instance: {{ .Release.Name }}
+        talksToHsm: ""
     spec:
       containers:
       - name: controller


### PR DESCRIPTION
Implementing the decision made in the following ADR:

https://github.com/alphagov/verify-proxy-node/blob/master/doc/adr/20190320-anti-affinity.md