### PR TITLE
EID-1437: Provide a verify-frontend url for Proxy Node errors

### DIFF
--- a/templates/gateway-deployment.yaml
+++ b/templates/gateway-deployment.yaml
@@ -53,3 +53,5 @@ spec:
           value: http://{{ .Release.Name }}-esp/
         - name: VERIFY_SERVICE_PROVIDER_URL
           value: http://{{ .Release.Name }}-vsp/
+        - name: PROXY_NODE_ERROR_PAGE_URI
+          value: {{ .Values.gateway.errorPageURL }}

--- a/values.yaml
+++ b/values.yaml
@@ -21,6 +21,7 @@ gateway:
     repository: registry.tools.verify.govsvc.uk/eidas/gateway
     tag: v0.0.0-dev-2626120
     pullPolicy: IfNotPresent
+  errorPageURL: https://www.signin.service.gov.uk/proxy-node-error
 
 hsm:
   IP:


### PR DESCRIPTION
Proxy Node will expect the env variable `PROXY_NODE_ERROR_PAGE_URI` to be present when evaluating the error page to use for SAML processing errors.

This PR will provide the production url, another PR will update with environment specific values.